### PR TITLE
Update Action vers to handle GHA deprecations

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,11 +16,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set Python 3 as default
 
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
 
       with:
         python-version: 3
@@ -40,7 +40,7 @@ runs:
 
     - name: Publish results in the Pipeline Artifact
 
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
 
       with:
         path: ${{ env.Pipeline.Workspace }}/tmp/detect-secrets.json


### PR DESCRIPTION
Node 12 and set-output are deprecated by GitHub Actions.  This is kicking up warnings from some of the Actions here, which have thankfully been updated.

GitHub Blog for node 12:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

GitHub Blog for set-output (and save-state):
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Workflow warnings:

- `Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v1, actions/upload-artifact@v2`
- `The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/`